### PR TITLE
Fix Limit 0 problem

### DIFF
--- a/src/Customer.php
+++ b/src/Customer.php
@@ -12,7 +12,7 @@ class Customer extends DocbeeAPICall
     public function count(): int
     {
         // Get only one entry because we need only the total count data
-        $result = $this->call(['limit' => 1]);
+        $result = $this->call(['limit' => 0]);
         return is_array($result) && isset($result['totalCount']) ? $result['totalCount'] : 0;
     }
 
@@ -25,10 +25,17 @@ class Customer extends DocbeeAPICall
      * @param string $changedSince load all entries after given date
      * @return array The result
      */
-    public function get(int $limit = 0, int $offset = 0, string $fields = '', string $changedSince = ''): array
+    public function get(int $limit = -1, int $offset = -1, string $fields = '', string $changedSince = ''): array
     {
         $this->subFunction = '';
-        $data = array('limit' => $limit, 'offset' => $offset, 'fields' => $fields, 'changedSince' => $changedSince);
+        $data = array('changedSince' => $changedSince);
+
+        // Only if the fields are set, take them in the request
+        if($limit != -1)    $data['limit'] = $limit;
+        if($offset != -1)    $data['offset'] = $offset;
+        if($fields != '')    $data['fields'] = $fields;
+        if($changedSince != '') $data['changedSince'] = $changedSince;
+
         $result = $this->call($data);
 
         // Gets only the customers without other fields

--- a/src/CustomerContact.php
+++ b/src/CustomerContact.php
@@ -25,7 +25,7 @@ class CustomerContact extends DocbeeAPICall
     public function count(): int
     {
         // Get only one entry because we need only the total count data
-        $result = $this->call(['limit' => 1]);
+        $result = $this->call(['limit' => 0]);
         return is_array($result) && isset($result['totalCount']) ? $result['totalCount'] : 0;
     }
 
@@ -38,10 +38,17 @@ class CustomerContact extends DocbeeAPICall
      * @param string $changedSince load all entries after given date
      * @return array The result
      */
-    public function get(int $limit = 0, int $offset = 0, string $fields = '', string $changedSince = ''): array
+    public function get(int $limit = -1, int $offset = -1, string $fields = '', string $changedSince = ''): array
     {
         $this->subFunction = '';
-        $data = array('customer' => $this->customerId, 'limit' => $limit, 'offset' => $offset, 'fields' => $fields, 'changedSince' => $changedSince);
+        $data = array('customer' => $this->customerId, 'changedSince' => $changedSince);
+
+        // Only if the fields are set, take them in the request
+        if($limit != -1)    $data['limit'] = $limit;
+        if($offset != -1)    $data['offset'] = $offset;
+        if($fields != '')    $data['fields'] = $fields;
+        if($changedSince != '') $data['changedSince'] = $changedSince;
+
         $result = $this->call($data);
 
         // Gets only the customers without other fields

--- a/src/CustomerStatus.php
+++ b/src/CustomerStatus.php
@@ -13,10 +13,16 @@ class CustomerStatus extends DocbeeAPICall
      * @param string $changedSince load all entries after given date
      * @return array The result
      */
-    public function get(int $limit = 0, int $offset = 0, string $fields = ''): array
+    public function get(int $limit = -1, int $offset = -1, string $fields = ''): array
     {
         $this->subFunction = '';
-        $data = array('limit' => $limit, 'offset' => $offset, 'fields' => $fields);
+        $data = array();
+
+        // Only if the fields are set, take them in the request
+        if($limit != -1)    $data['limit'] = $limit;
+        if($offset != -1)    $data['offset'] = $offset;
+        if($fields != '')    $data['fields'] = $fields;
+
         $result = $this->call($data);
 
         // Gets only the customers without other fields

--- a/src/DocBeeDocument.php
+++ b/src/DocBeeDocument.php
@@ -23,7 +23,7 @@ class DocBeeDocument extends DocbeeAPICall
     public function count(): int
     {
         // Get only one entry because we need only the total count data
-        $result = $this->call(['limit' => 1]);
+        $result = $this->call(['limit' => 0]);
         return is_array($result) && isset($result['totalCount']) ? $result['totalCount'] : 0;
     }
 
@@ -36,10 +36,17 @@ class DocBeeDocument extends DocbeeAPICall
      * @param string $changedSince load all entries after given date
      * @return array The result
      */
-    public function get(int $limit = 0, int $offset = 0, string $fields = '', string $changedSince = ''): array
+    public function get(int $limit = -1, int $offset = -1, string $fields = '', string $changedSince = ''): array
     {
         $this->subFunction = '';
-        $data = array('limit' => $limit, 'offset' => $offset, 'fields' => $fields, 'changedSince' => $changedSince);
+        $data = array();
+
+        // Only if the fields are set, take them in the request
+        if($limit != -1)    $data['limit'] = $limit;
+        if($offset != -1)    $data['offset'] = $offset;
+        if($fields != '')    $data['fields'] = $fields;
+        if($changedSince != '') $data['changedSince'] = $changedSince;
+
         $result = $this->call($data);
 
         // Gets only the Tickets without other fields

--- a/src/DocBeeDocumentTask.php
+++ b/src/DocBeeDocumentTask.php
@@ -31,7 +31,7 @@ class DocBeeDocumentTask extends DocbeeAPICall
         $this->checkCall();
 
         // Get only one entry because we need only the total count data
-        $result = $this->call(['limit' => 1]);
+        $result = $this->call(['limit' => 0]);
         return is_array($result) && isset($result['totalCount']) ? $result['totalCount'] : 0;
     }
 
@@ -44,12 +44,18 @@ class DocBeeDocumentTask extends DocbeeAPICall
      * @return array The result
      * @throws \InvalidArgumentException When the documentId is not set
      */
-    public function get(int $limit = 0, int $offset = 0, string $fields = ''): array
+    public function get(int $limit = -1, int $offset = -1, string $fields = ''): array
     {
         $this->checkCall();
 
         $this->subFunction = '';
-        $data = array('limit' => $limit, 'offset' => $offset, 'fields' => $fields);
+        $data = array();
+
+        // Only if the fields are set, take them in the request
+        if($limit != -1)    $data['limit'] = $limit;
+        if($offset != -1)    $data['offset'] = $offset;
+        if($fields != '')    $data['fields'] = $fields;
+
         $result = $this->call($data);
 
         // Gets only the Tickets without other fields

--- a/src/Priority.php
+++ b/src/Priority.php
@@ -13,10 +13,16 @@ class Priority extends DocbeeAPICall
      * @param bool $deactivated deactivated priority?
      * @return array The result
      */
-    public function get(int $limit = 0, int $offset = 0, string $fields = '', bool $deactivated = false): array
+    public function get(int $limit = -1, int $offset = -1, string $fields = '', bool $deactivated = false): array
     {
         $this->subFunction = '';
-        $data = array('limit' => $limit, 'offset' => $offset, 'fields' => $fields, 'deactivated' => $deactivated);
+        $data = array('deactivated' => $deactivated);
+
+        // Only if the fields are set, take them in the request
+        if($limit != -1)    $data['limit'] = $limit;
+        if($offset != -1)    $data['offset'] = $offset;
+        if($fields != '')    $data['fields'] = $fields;
+
         $result = $this->call($data);
 
         // Gets only the priorities without other fields

--- a/src/ServiceType.php
+++ b/src/ServiceType.php
@@ -13,10 +13,16 @@ class ServiceType extends DocbeeAPICall
      * @param bool $deactivated deactivated service type?
      * @return array The result
      */
-    public function get(int $limit = 0, int $offset = 0, string $fields = '', bool $deactivated = false): array
+    public function get(int $limit = -1, int $offset = -1, string $fields = '', bool $deactivated = false): array
     {
         $this->subFunction = '';
-        $data = array('limit' => $limit, 'offset' => $offset, 'fields' => $fields, 'deactivated' => $deactivated);
+        $data = array('deactivated' => $deactivated);
+
+        // Only if the fields are set, take them in the request
+        if($limit != -1)    $data['limit'] = $limit;
+        if($offset != -1)    $data['offset'] = $offset;
+        if($fields != '')    $data['fields'] = $fields;
+
         $result = $this->call($data);
 
         // Gets only the service types without other fields

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -13,10 +13,16 @@ class Tag extends DocbeeAPICall
      * @param bool $deactivated deactivated tag?
      * @return array The result
      */
-    public function get(int $limit = 0, int $offset = 0, string $fields = '', bool $deactivated = false): array
+    public function get(int $limit = -1, int $offset = -1, string $fields = '', bool $deactivated = false): array
     {
         $this->subFunction = '';
-        $data = array('limit' => $limit, 'offset' => $offset, 'fields' => $fields, 'deactivated' => $deactivated);
+        $data = array('deactivated' => $deactivated);
+
+        // Only if the fields are set, take them in the request
+        if($limit != -1)    $data['limit'] = $limit;
+        if($offset != -1)    $data['offset'] = $offset;
+        if($fields != '')    $data['fields'] = $fields;
+
         $result = $this->call($data);
 
         // Gets only the tags without other fields

--- a/src/Ticket.php
+++ b/src/Ticket.php
@@ -23,7 +23,7 @@ class Ticket extends DocbeeAPICall
     public function count(): int
     {
         // Get only one entry because we need only the total count data
-        $result = $this->call(['limit' => 1]);
+        $result = $this->call(['limit' => 0]);
         return is_array($result) && isset($result['totalCount']) ? $result['totalCount'] : 0;
     }
 
@@ -36,10 +36,17 @@ class Ticket extends DocbeeAPICall
      * @param string $changedSince load all entries after given date
      * @return array The result
      */
-    public function get(int $limit = 0, int $offset = 0, string $fields = '', string $changedSince = ''): array
+    public function get(int $limit = -1, int $offset = -1, string $fields = '', string $changedSince = ''): array
     {
         $this->subFunction = '';
-        $data = array('limit' => $limit, 'offset' => $offset, 'fields' => $fields, 'changedSince' => $changedSince);
+        $data = array();
+
+        // Only if the fields are set, take them in the request
+        if($limit != -1)    $data['limit'] = $limit;
+        if($offset != -1)    $data['offset'] = $offset;
+        if($fields != '')    $data['fields'] = $fields;
+        if($changedSince != '') $data['changedSince'] = $changedSince;
+
         $result = $this->call($data);
 
         // Gets only the Tickets without other fields

--- a/src/TicketStatus.php
+++ b/src/TicketStatus.php
@@ -13,10 +13,16 @@ class TicketStatus extends DocbeeAPICall
      * @param bool $deactivated deactivated ticket status?
      * @return array The result
      */
-    public function get(int $limit = 0, int $offset = 0, string $fields = '', bool $deactivated = false): array
+    public function get(int $limit = -1, int $offset = -1, string $fields = '', bool $deactivated = false): array
     {
         $this->subFunction = '';
-        $data = array('limit' => $limit, 'offset' => $offset, 'fields' => $fields, 'deactivated' => $deactivated);
+        $data = array('deactivated' => $deactivated);
+
+        // Only if the fields are set, take them in the request
+        if($limit != -1)    $data['limit'] = $limit;
+        if($offset != -1)    $data['offset'] = $offset;
+        if($fields != '')    $data['fields'] = $fields;
+
         $result = $this->call($data);
 
         // Gets only the ticket status without other fields

--- a/src/User.php
+++ b/src/User.php
@@ -13,10 +13,16 @@ class User extends DocbeeAPICall
      * @param bool $deactivated deactivated user?
      * @return array The result
      */
-    public function get(int $limit = 0, int $offset = 0, string $fields = '', bool $deactivated = false): array
+    public function get(int $limit = -1, int $offset = -1, string $fields = '', bool $deactivated = false): array
     {
         $this->subFunction = '';
-        $data = array('limit' => $limit, 'offset' => $offset, 'fields' => $fields, 'deactivated' => $deactivated);
+        $data = array('deactivated' => $deactivated);
+
+        // Only if the fields are set, take them in the request
+        if($limit != -1)    $data['limit'] = $limit;
+        if($offset != -1)    $data['offset'] = $offset;
+        if($fields != '')    $data['fields'] = $fields;
+
         $result = $this->call($data);
 
         // Gets only the user without other fields
@@ -45,7 +51,7 @@ class User extends DocbeeAPICall
     public function getUserFromName(string $name = '', string $mail = ''): array
     {
         $this->subFunction = '';
-        $users = $this->get(0,0,'*');
+        $users = $this->get(-1,-1,'*');
 
         if (is_array($users) && count($users) > 0) {
             foreach ($users as $user) {


### PR DESCRIPTION
A change to the API has caused issues with all default settings where the limit is set to 0.

Previously, specifying a limit of 0 would return all values. Now, setting the limit to 0 actually loads no data. This is intended, for example, when making a count but no values are needed.

As a result, all values have now been adjusted so that the default settings are marked with -1. If -1 or an empty string is present, the data will no longer be transmitted during a request. This ensures that no parameters are passed unless absolutely necessary. If another value is specified, it will, of course, be transmitted.

This has been implemented in almost all classes.